### PR TITLE
Add -x developer mode to disable auth checks completely.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ test-output
 
 dependency-reduced-pom.xml
 
+# config for running developers
+developer_config

--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ If you do this, be sure to include wagon-ssh-external artifact in your project's
 To run the proxy locally, do the following:
 
 1.  Create a config and an auth file.
-1.  Build the jar if you haven't already:  `mvn clean install`
-2.  Get your classpath:  `mvn dependency:build-classpath -Dmdep.outputFile=target/sshd_classpath`
-3.  Run the proxy:  ``java -cp target/sshd_proxy-0.2.0-SNAPSHOT.jar:`cat target/sshd_classpath` com.yahoo.sshd.server.Sshd -f src/main/resources/sshd_proxy.properties``
+    1. sh create_config.sh will create one for you.
+    1. -x below negates the need for an auth file.
+2.  Build the jar if you haven't already:  `mvn clean install`
+3.  Get your classpath:  `mvn dependency:build-classpath -Dmdep.outputFile=target/sshd_classpath`
+4.  Run the proxy:  ``java -cp target/sshd_proxy-0.2.0-SNAPSHOT.jar:`cat target/sshd_classpath` com.yahoo.sshd.server.Sshd -r developer_config -x``
 
 ## Misc notes.
 

--- a/create_config.sh
+++ b/create_config.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# This script is used to one time create the config directory for development setup.
+ROOT=developer_config
+
+# gack die ROOT die.
+mkdir -p $ROOT/conf/sshd_proxy/
+mkdir -p $ROOT/logs/sshd_proxy
+
+# create the hostkey
+ssh-keygen -t dsa -f $ROOT/conf/sshd_proxy/ssh_host_dsa_key -C '' -N ''
+
+# copy the properties file
+cp src/test/resources/developer_config/sshd_proxy.properties  $ROOT/conf/sshd_proxy/sshd_proxy.properties
+
+# fix ROOT to be our root.
+sed -i '' -e s/sshd.root=.*/sshd.root=$ROOT/g $ROOT/conf/sshd_proxy/sshd_proxy.properties

--- a/src/main/java/com/yahoo/sshd/authorization/WideOpenGatesAuthrorizer.java
+++ b/src/main/java/com/yahoo/sshd/authorization/WideOpenGatesAuthrorizer.java
@@ -1,0 +1,31 @@
+package com.yahoo.sshd.authorization;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yahoo.sshd.authorization.file.FileBasedArtifactoryAuthorizer;
+import com.yahoo.sshd.server.settings.SshdSettingsInterface;
+
+/**
+ * Added this to make doing dev work a lot less painful. I don't want to setup an auth.txt for doing local development,
+ * so add a flag. The problem is, we probably should flag this separately, because later we might create a developer
+ * version that hosts more bits. When that is done, we'll have to rethink this.
+ * 
+ * @author areese
+ * 
+ */
+public class WideOpenGatesAuthrorizer implements ArtifactoryAuthorizer {
+    private static final Logger LOG = LoggerFactory.getLogger(FileBasedArtifactoryAuthorizer.class);
+
+    public WideOpenGatesAuthrorizer(SshdSettingsInterface settings) {
+
+    }
+
+    @Override
+    public boolean authorized(String repositoryName, String userName, ArtifactoryPermTargetType permissionTarget) {
+        LOG.info("Development mode, blindly allowing user: '{}' access to repo: '{}' with target '{}", userName,
+                        repositoryName, permissionTarget);
+        return true;
+    }
+
+}

--- a/src/main/java/com/yahoo/sshd/authorization/file/ArtifactoryAuthFileEventHandler.java
+++ b/src/main/java/com/yahoo/sshd/authorization/file/ArtifactoryAuthFileEventHandler.java
@@ -20,8 +20,18 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.yahoo.sshd.utils.DirectoryWatchService;
 import com.yahoo.sshd.utils.DirectoryWatchServiceEventHandler;
 
+/**
+ * This class is used by {@link ArtifactoryAuthorizerFileScanner} to deal with events fired by the
+ * {@link DirectoryWatchService} implemented by {@link ArtifactoryAuthorizerFileScanner}
+ * 
+ * It hands parsing off to {@link AuthFileParser} which currently isn't replacable.
+ * 
+ * @author areese
+ * 
+ */
 public class ArtifactoryAuthFileEventHandler implements DirectoryWatchServiceEventHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(ArtifactoryAuthFileEventHandler.class);
 
@@ -63,6 +73,8 @@ public class ArtifactoryAuthFileEventHandler implements DirectoryWatchServiceEve
     }
 
     private void reload(Path changed) throws FileNotFoundException {
+        // TODO: allow this to be overriden
+        // TODO: fix this to not be static, so behaviour can change
         AuthFileParser.parse(changed.toFile().getAbsolutePath(), authorizationHashMap);
     }
 }

--- a/src/main/java/com/yahoo/sshd/authorization/file/AuthFileParser.java
+++ b/src/main/java/com/yahoo/sshd/authorization/file/AuthFileParser.java
@@ -24,6 +24,12 @@ import org.slf4j.LoggerFactory;
 
 import com.yahoo.sshd.authorization.ArtifactoryPermTargetType;
 
+/**
+ * This class parses an auth.txt and builds a permissions map of repo -> {@link PermTarget}.
+ * 
+ * @author areese
+ * 
+ */
 public class AuthFileParser {
     private static final Logger LOG = LoggerFactory.getLogger(AuthFileParser.class);
 

--- a/src/main/java/com/yahoo/sshd/authorization/file/DefaultArtifactoryAuthorizerProviderFactory.java
+++ b/src/main/java/com/yahoo/sshd/authorization/file/DefaultArtifactoryAuthorizerProviderFactory.java
@@ -12,14 +12,24 @@
  */
 package com.yahoo.sshd.authorization.file;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.yahoo.sshd.authorization.ArtifactoryAuthorizer;
 import com.yahoo.sshd.authorization.ArtifactoryAuthorizerProviderFactory;
+import com.yahoo.sshd.authorization.WideOpenGatesAuthrorizer;
 import com.yahoo.sshd.server.settings.SshdSettingsInterface;
 
 public class DefaultArtifactoryAuthorizerProviderFactory implements ArtifactoryAuthorizerProviderFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(FileBasedArtifactoryAuthorizer.class);
 
     @Override
     public ArtifactoryAuthorizer artifactoryAuthorizerProvider(SshdSettingsInterface settings) {
+        if (settings.isDevelopementMode()) {
+            LOG.warn("Running in developement mode, many checks are disabled");
+            return new WideOpenGatesAuthrorizer(settings);
+        }
+
         return new FileBasedArtifactoryAuthorizer(settings);
     }
 

--- a/src/main/java/com/yahoo/sshd/authorization/file/FileBasedArtifactoryAuthorizer.java
+++ b/src/main/java/com/yahoo/sshd/authorization/file/FileBasedArtifactoryAuthorizer.java
@@ -25,6 +25,13 @@ import com.yahoo.sshd.authorization.ArtifactoryPermTargetType;
 import com.yahoo.sshd.server.settings.SshdSettingsInterface;
 import com.yahoo.sshd.utils.ThreadUtils;
 
+/**
+ * This class watches the file specified by {@link SshdSettingsInterface#getArtifactoryAuthorizationFilePath()} and
+ * authorizes users based upon it's content.
+ * 
+ * @author areese
+ * 
+ */
 public class FileBasedArtifactoryAuthorizer implements ArtifactoryAuthorizer {
     private static final Logger LOG = LoggerFactory.getLogger(FileBasedArtifactoryAuthorizer.class);
 

--- a/src/main/java/com/yahoo/sshd/server/SshServerWrapper.java
+++ b/src/main/java/com/yahoo/sshd/server/SshServerWrapper.java
@@ -1,0 +1,182 @@
+package com.yahoo.sshd.server;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.sshd.SshServer;
+import org.apache.sshd.common.KeyPairProvider;
+import org.apache.sshd.common.forward.DefaultTcpipForwarderFactory;
+import org.apache.sshd.common.util.CloseableUtils;
+import org.apache.sshd.server.keyprovider.PEMHostKeyProviderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.yahoo.sshd.authorization.ArtifactoryAuthorizerProviderFactory;
+import com.yahoo.sshd.server.command.DelegatingCommandFactory;
+import com.yahoo.sshd.server.configuration.DenyingForwardingFilter;
+import com.yahoo.sshd.server.filesystem.InjectableArtifactoryFileSystemFactory;
+import com.yahoo.sshd.server.logging.RequestLogFactory;
+import com.yahoo.sshd.server.logging.SshRequestLog;
+import com.yahoo.sshd.server.settings.SshdConfigurationException;
+import com.yahoo.sshd.server.settings.SshdSettingsFactory;
+import com.yahoo.sshd.server.settings.SshdSettingsInterface;
+import com.yahoo.sshd.server.settings.SshdSettingsModule;
+import com.yahoo.sshd.utils.RunnableComponent;
+import com.yahoo.sshd.utils.ThreadUtils;
+
+public class SshServerWrapper implements Runnable, Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SshServerWrapper.class);
+
+    private final SshdSettingsInterface settings;
+    private final SshServer sshd;
+    private final Injector injector;
+
+    private final InjectableArtifactoryFileSystemFactory afFsFactory;
+
+    private final KeyPairProvider keyPairProvider;
+    private final SshRequestLog requestLog;
+
+    private final CountDownLatch countdownLatch = new CountDownLatch(1);
+
+    public SshServerWrapper(String[] args) throws SshdConfigurationException {
+        /*
+         * Guice.createInjector() takes your Modules, and returns a new Injector instance. Most applications will call
+         * this method exactly once, in their main() method.
+         */
+        SshdSettingsModule sshdSettingsModule = new SshdSettingsModule();
+        this.injector = Guice.createInjector(sshdSettingsModule);
+
+        SshdSettingsFactory settingsFactory = injector.getInstance(SshdSettingsFactory.class);
+        this.settings = settingsFactory.createSshdSettings(args);
+
+        this.afFsFactory = injector.getInstance(InjectableArtifactoryFileSystemFactory.class);
+        this.afFsFactory.setAfInfo(this.settings.getArtifactoryInfo());
+        this.afFsFactory.setArtifactoryAuthorizer(injector.getInstance(ArtifactoryAuthorizerProviderFactory.class)
+                        .artifactoryAuthorizerProvider(this.settings));
+        this.keyPairProvider =
+                        injector.getInstance(PEMHostKeyProviderFactory.class).createPEMHostKeyProvider(
+                                        this.settings.getHostKeyPath());
+        this.requestLog =
+                        injector.getInstance(RequestLogFactory.class).createRequestLog(
+                                        this.settings.getRequestLogPath());
+
+        // Setup the request log for each command factory.
+        for (DelegatingCommandFactory cf : this.settings.getCfInstances()) {
+            cf.setRequestLog(this.requestLog);
+        }
+
+        LOGGER.debug("Got FS Factory: " + this.afFsFactory.getClass().getCanonicalName());
+
+        sshd = SshServer.setUpDefaultServer();
+        sshd.setPort(settings.getPort());
+
+        sshd.setKeyPairProvider(this.keyPairProvider);
+
+        // setup the executor to have more than 1 thread.
+        sshd.setScheduledExecutorService(ThreadUtils.scheduledExecutorServer(), true);
+
+        // setup the shell to only provide a message and nothing else.
+        sshd.setShellFactory(settings.getShellFactory());
+
+        // setup the filesystem view to make it look at artifactory instead of
+        // the fs.
+        sshd.setFileSystemFactory(afFsFactory);
+
+        // this lets us do weirdness, which is to configure where we look for
+        // commands
+        sshd.setCommandFactory(settings.getCommandFactory());
+
+        // DENY all ssh forwarding.
+        sshd.setTcpipForwardingFilter(new DenyingForwardingFilter());
+
+        sshd.setTcpipForwarderFactory(new DefaultTcpipForwarderFactory());
+
+        // explicitly disable all auth except pkauth see
+        // org.apache.sshd.SshServer.checkConfig()
+        sshd.setPasswordAuthenticator(null);
+        sshd.setGSSAuthenticator(null);
+
+        // set number of NIO Workers.
+        sshd.setNioWorkers(settings.getNioWorkers());
+
+        // explicitly disable agentFactory
+        sshd.setAgentFactory(null);
+
+        // only allow specific ciphers if configured, otherwise defaults will be
+        // used.
+        sshd.setCipherFactories(settings.getCiphers());
+
+        try {
+            sshd.setPublickeyAuthenticator(settings.getPublickeyAuthenticator());
+        } catch (IOException | InterruptedException e) {
+            LOGGER.error("PublicKey Auth loading failed", e);
+            throw new RuntimeException("PublicKey Auth loading failed", e);
+        }
+
+        try {
+            requestLog.setup();
+        } catch (Exception e) {
+            LOGGER.error("failed to set up request log", e);
+            throw new RuntimeException("start failed", e);
+        }
+    }
+
+    @Override
+    public void run() {
+        for (RunnableComponent component : settings.getExternalComponents()) {
+            try {
+                ThreadUtils.externalsThreadPool().submit(component);
+            } catch (Exception e) {
+                LOGGER.error("start of " + component.getName() + " failed", e);
+                throw new RuntimeException("start failed", e);
+            }
+        }
+
+        LOGGER.info("Starting SSHD on port " + settings.getPort());
+        try {
+            sshd.start();
+        } catch (IOException e) {
+            LOGGER.error("start failed", e);
+            throw new RuntimeException("start failed", e);
+        }
+    }
+
+
+    @Override
+    public void close() throws IOException {
+        try {
+            LOGGER.info("Stopping external services");
+            // stop jetty et. al.
+            // reverse the order so we stop in the opposite order we started.
+            List<RunnableComponent> list = Arrays.asList(settings.getExternalComponents());
+            Collections.reverse(list);
+            CloseableUtils.sequential(list.toArray(new RunnableComponent[] {})).close(false).await();
+
+            LOGGER.info("Stopping sshd");
+            sshd.stop();
+
+            try {
+                // close request log file
+                requestLog.close();
+            } catch (Exception e) {
+                LOGGER.warn("failed to clean up requestLog", e);
+            }
+
+            LOGGER.info("Exiting");
+        } catch (InterruptedException e) {
+            throw new IOException(e);
+        } finally {
+            countdownLatch.countDown();
+        }
+    }
+
+    public CountDownLatch getLatch() {
+        return countdownLatch;
+    }
+}

--- a/src/main/java/com/yahoo/sshd/server/Sshd.java
+++ b/src/main/java/com/yahoo/sshd/server/Sshd.java
@@ -13,38 +13,15 @@
 package com.yahoo.sshd.server;
 
 import java.io.IOException;
-import java.security.Security;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
 import org.apache.commons.daemon.Daemon;
 import org.apache.commons.daemon.DaemonContext;
 import org.apache.commons.daemon.DaemonInitException;
-import org.apache.sshd.SshServer;
-import org.apache.sshd.common.KeyPairProvider;
-import org.apache.sshd.common.forward.DefaultTcpipForwarderFactory;
-import org.apache.sshd.common.util.CloseableUtils;
-import org.apache.sshd.common.util.SecurityUtils;
-import org.apache.sshd.server.keyprovider.PEMHostKeyProviderFactory;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.inject.Guice;
-import com.google.inject.Injector;
-import com.yahoo.sshd.authorization.ArtifactoryAuthorizerProviderFactory;
-import com.yahoo.sshd.server.command.DelegatingCommandFactory;
-import com.yahoo.sshd.server.configuration.DenyingForwardingFilter;
-import com.yahoo.sshd.server.filesystem.InjectableArtifactoryFileSystemFactory;
-import com.yahoo.sshd.server.logging.RequestLogFactory;
-import com.yahoo.sshd.server.logging.SshRequestLog;
 import com.yahoo.sshd.server.settings.SshdConfigurationException;
-import com.yahoo.sshd.server.settings.SshdSettingsFactory;
-import com.yahoo.sshd.server.settings.SshdSettingsInterface;
-import com.yahoo.sshd.server.settings.SshdSettingsModule;
-import com.yahoo.sshd.utils.RunnableComponent;
-import com.yahoo.sshd.utils.ThreadUtils;
 
 public class Sshd implements Daemon, Runnable {
     private static final Logger LOGGER = LoggerFactory.getLogger(Sshd.class);
@@ -58,17 +35,7 @@ public class Sshd implements Daemon, Runnable {
      */
     private String[] args;
 
-    // TODO not sure we need this.
-    private SshdSettingsFactory settingsFactory;
-
-    private SshdSettingsInterface settings;
-    private SshServer sshd;
-    private Injector injector;
-
-    private InjectableArtifactoryFileSystemFactory afFsFactory;
-
-    private KeyPairProvider keyPairProvider;
-    private SshRequestLog requestLog;
+    private SshServerWrapper sshServer;
 
     /**
      * constructor used by jsvc
@@ -80,7 +47,6 @@ public class Sshd implements Daemon, Runnable {
     /**
      * constructor used by main.
      * 
-     * @param settingsFactory
      * @param args
      * @throws SshdConfigurationException
      */
@@ -96,117 +62,23 @@ public class Sshd implements Daemon, Runnable {
      * @throws SshdConfigurationException
      */
     protected void setup() throws SshdConfigurationException {
-        /*
-         * Guice.createInjector() takes your Modules, and returns a new Injector instance. Most applications will call
-         * this method exactly once, in their main() method.
-         */
-        SshdSettingsModule sshdSettingsModule = new SshdSettingsModule();
-        this.injector = Guice.createInjector(sshdSettingsModule);
-        this.settingsFactory = injector.getInstance(SshdSettingsFactory.class);
-        this.settings = this.settingsFactory.createSshdSettings(this.args);
-        this.afFsFactory = injector.getInstance(InjectableArtifactoryFileSystemFactory.class);
-        this.afFsFactory.setAfInfo(this.settings.getArtifactoryInfo());
-        this.afFsFactory.setArtifactoryAuthorizer(injector.getInstance(ArtifactoryAuthorizerProviderFactory.class)
-                        .artifactoryAuthorizerProvider(this.settings));
-        this.keyPairProvider =
-                        injector.getInstance(PEMHostKeyProviderFactory.class).createPEMHostKeyProvider(
-                                        this.settings.getHostKeyPath());
-        this.requestLog =
-                        injector.getInstance(RequestLogFactory.class).createRequestLog(
-                                        this.settings.getRequestLogPath());
-
-        // Setup the request log for each command factory.
-        for (DelegatingCommandFactory cf : this.settings.getCfInstances()) {
-            cf.setRequestLog(this.requestLog);
-        }
-
-        LOGGER.debug("Got FS Factory: " + this.afFsFactory.getClass().getCanonicalName());
+        this.sshServer = new SshServerWrapper(this.args);
     }
 
     public static void main(String[] args) throws Exception {
         Sshd sshd = new Sshd(args);
         sshd.run();
+
+        sshd.getLatch().await();
+    }
+
+    private CountDownLatch getLatch() {
+        return sshServer.getLatch();
     }
 
     @Override
     public void run() {
-
-        // load bouncycastle first, and fail fast.
-        Security.addProvider(new BouncyCastleProvider());
-        if (!SecurityUtils.isBouncyCastleRegistered()) {
-            throw new RuntimeException(
-                            "BouncyCastle must be registered: http://www.bouncycastle.org/wiki/display/JA1/Provider+Installation");
-        }
-
-        sshd = SshServer.setUpDefaultServer();
-        sshd.setPort(settings.getPort());
-
-        sshd.setKeyPairProvider(this.keyPairProvider);
-
-        // setup the executor to have more than 1 thread.
-        sshd.setScheduledExecutorService(ThreadUtils.scheduledExecutorServer(), true);
-
-        // setup the shell to only provide a message and nothing else.
-        sshd.setShellFactory(settings.getShellFactory());
-
-        // setup the filesystem view to make it look at artifactory instead of
-        // the fs.
-        sshd.setFileSystemFactory(afFsFactory);
-
-        // this lets us do weirdness, which is to configure where we look for
-        // commands
-        sshd.setCommandFactory(settings.getCommandFactory());
-
-        // DENY all ssh forwarding.
-        sshd.setTcpipForwardingFilter(new DenyingForwardingFilter());
-
-        sshd.setTcpipForwarderFactory(new DefaultTcpipForwarderFactory());
-
-        // explicitly disable all auth except pkauth see
-        // org.apache.sshd.SshServer.checkConfig()
-        sshd.setPasswordAuthenticator(null);
-        sshd.setGSSAuthenticator(null);
-
-        // set number of NIO Workers.
-        sshd.setNioWorkers(settings.getNioWorkers());
-
-        // explicitly disable agentFactory
-        sshd.setAgentFactory(null);
-
-        // only allow specific ciphers if configured, otherwise defaults will be
-        // used.
-        sshd.setCipherFactories(settings.getCiphers());
-
-        try {
-            sshd.setPublickeyAuthenticator(settings.getPublickeyAuthenticator());
-        } catch (IOException | InterruptedException e) {
-            LOGGER.error("PublicKey Auth loading failed", e);
-            throw new RuntimeException("PublicKey Auth loading failed", e);
-        }
-
-        for (RunnableComponent component : settings.getExternalComponents()) {
-            try {
-                ThreadUtils.externalsThreadPool().submit(component);
-            } catch (Exception e) {
-                LOGGER.error("start of " + component.getName() + " failed", e);
-                throw new RuntimeException("start failed", e);
-            }
-        }
-
-        try {
-            requestLog.setup();
-        } catch (Exception e) {
-            LOGGER.error("failed to set up request log", e);
-            throw new RuntimeException("start failed", e);
-        }
-
-        LOGGER.info("Starting SSHD on port " + settings.getPort());
-        try {
-            sshd.start();
-        } catch (IOException e) {
-            LOGGER.error("start failed", e);
-            throw new RuntimeException("start failed", e);
-        }
+        sshServer.run();
     }
 
     /**
@@ -263,17 +135,7 @@ public class Sshd implements Daemon, Runnable {
      */
     @Override
     public void stop() throws InterruptedException, IOException {
-        LOGGER.info("Stopping external services");
-        // stop jetty et. al.
-        // reverse the order so we stop in the opposite order we started.
-        List<RunnableComponent> list = Arrays.asList(settings.getExternalComponents());
-        Collections.reverse(list);
-        CloseableUtils.sequential(list.toArray(new RunnableComponent[] {})).close(false).await();
-
-        LOGGER.info("Stopping sshd");
-        sshd.stop();
-
-        LOGGER.info("Exiting");
+        sshServer.close();
     }
 
     /**
@@ -283,15 +145,6 @@ public class Sshd implements Daemon, Runnable {
      */
     @Override
     public void destroy() {
-        cleanup();
-    }
 
-    protected void cleanup() {
-        try {
-            // close request log file
-            requestLog.cleanup();
-        } catch (Exception e) {
-            LOGGER.warn("failed to clean up requestLog", e);
-        }
     }
 }

--- a/src/main/java/com/yahoo/sshd/server/logging/NCSARequestLog.java
+++ b/src/main/java/com/yahoo/sshd/server/logging/NCSARequestLog.java
@@ -231,7 +231,7 @@ public class NCSARequestLog extends AbstractNCSARequestLog implements SshRequest
      * @see org.eclipse.jetty.util.component.AbstractLifeCycle#doStop()
      */
     @Override
-    public void cleanup() throws Exception {
+    public void close() throws IOException {
         if (LOG.isDebugEnabled()) {
             LOG.debug("cleaning up NCSARequestLog");
         }

--- a/src/main/java/com/yahoo/sshd/server/logging/SshRequestLog.java
+++ b/src/main/java/com/yahoo/sshd/server/logging/SshRequestLog.java
@@ -12,13 +12,13 @@
  */
 package com.yahoo.sshd.server.logging;
 
+import java.io.Closeable;
 
-public interface SshRequestLog {
+
+public interface SshRequestLog extends Closeable {
 
     public void log(SshRequestInfo request);
 
     public void setup() throws Exception;
-
-    public void cleanup() throws Exception;
 
 }

--- a/src/main/java/com/yahoo/sshd/server/settings/SshdProxySettings.java
+++ b/src/main/java/com/yahoo/sshd/server/settings/SshdProxySettings.java
@@ -87,6 +87,8 @@ public class SshdProxySettings implements SshdSettingsInterface {
 
     protected final String artifactoryAuthorizationFilePath;
     protected final String requestLogFilePath;
+    
+    protected final boolean developmentMode;
 
     public SshdProxySettings(SshdSettingsBuilder b) throws SshdConfigurationException {
 
@@ -124,6 +126,8 @@ public class SshdProxySettings implements SshdSettingsInterface {
                             + ", user: " + artifactoryUsername + " and password: " + artifactoryPassword
                             + "  must be specified");
         }
+        
+        this.developmentMode = b.getDevelopmentMode();
     }
 
     /**
@@ -310,7 +314,7 @@ public class SshdProxySettings implements SshdSettingsInterface {
                 c.init(Cipher.Mode.Encrypt, key, iv);
                 available.add(factory);
             } catch (Exception e) {
-                LOGGER.info("Failed to load cipher " + cipherName, e);
+                LOGGER.info("Failed to load cipher " + cipherName + " ensure you have the unlimited strength JCE installed", e);
             }
         }
 
@@ -345,5 +349,15 @@ public class SshdProxySettings implements SshdSettingsInterface {
     @Override
     public int getHttpPort() {
         return httpPort;
+    }
+
+    /**
+     * Added this to make doing dev work a lot less painful. I don't want to setup an auth.txt for doing local
+     * development, so add a flag. The problem is, we probably should flag this separately, because later we might
+     * create a developer version that hosts more bits. When that is done, we'll have to rethink this.
+     */
+    @Override
+    public boolean isDevelopementMode() {
+        return developmentMode;
     }
 }

--- a/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsInterface.java
+++ b/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsInterface.java
@@ -68,4 +68,12 @@ public interface SshdSettingsInterface {
      * @return port http is listening on.
      */
     int getHttpPort();
+
+    /**
+     * Make a special flag for people running it on the desktop and debugging who really don't want to setup a lot of
+     * extra things that are required for production.
+     * 
+     * @return true if we are in development mode.
+     */
+    boolean isDevelopementMode();
 }

--- a/src/main/java/org/apache/sshd/server/keyprovider/PEMHostKeyProvider.java
+++ b/src/main/java/org/apache/sshd/server/keyprovider/PEMHostKeyProvider.java
@@ -65,11 +65,13 @@ public class PEMHostKeyProvider extends AbstractKeyPairProvider {
         try (InputStream is = new FileInputStream(f)) {
             return doReadKeyPair(is);
         } catch (Exception e) {
-            log.info("Unable to read key {}: {}", path, e);
+            //log.info("Unable to read key {}: {}", path, e);
+            throw new RuntimeException(e);
         }
-        return null;
+        //return null;
     }
 
+    @Override
     public synchronized Iterable<KeyPair> loadKeys() {
         ArrayList<KeyPair> keyPairList = new ArrayList<KeyPair>();
 

--- a/src/test/java/com/yahoo/sshd/authorization/file/TestArtifactoryAuthorization.java
+++ b/src/test/java/com/yahoo/sshd/authorization/file/TestArtifactoryAuthorization.java
@@ -19,6 +19,7 @@ import org.apache.sshd.common.Cipher;
 import org.apache.sshd.common.Factory;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.server.Command;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -38,73 +39,9 @@ public class TestArtifactoryAuthorization {
 
     @BeforeClass
     public void init() {
-        SshdSettingsInterface mockedSshdSettings = new SshdSettingsInterface() {
-            @Override
-            public int getPort() {
-                return 0;
-            }
-
-            @Override
-            public String getHostKeyPath() {
-                return null;
-            }
-
-            @Override
-            public DelegatingCommandFactory getCommandFactory() {
-                return null;
-            }
-
-            @Override
-            public List<DelegatingCommandFactory> getCfInstances() {
-                return null;
-            }
-
-            @Override
-            public MultiUserPKAuthenticator getPublickeyAuthenticator() throws IOException, InterruptedException {
-                return null;
-            }
-
-            @Override
-            public Factory<Command> getShellFactory() {
-                return null;
-            }
-
-            @Override
-            public ArtifactoryInformation getArtifactoryInfo() {
-                return null;
-            }
-
-            @Override
-            public int getNioWorkers() {
-                return 0;
-            }
-
-            @Override
-            public List<NamedFactory<Cipher>> getCiphers() {
-                return null;
-            }
-
-            @Override
-            public RunnableComponent[] getExternalComponents() {
-                return null;
-            }
-
-            @Override
-            public String getArtifactoryAuthorizationFilePath() {
-                return "src/test/resources/auth/auth.txt";
-            }
-
-            @Override
-            public String getRequestLogPath() {
-                return null;
-            }
-
-            @Override
-            public int getHttpPort() {
-                return 0;
-            }
-
-        };
+        SshdSettingsInterface mockedSshdSettings = Mockito.mock(SshdSettingsInterface.class);
+        Mockito.when(mockedSshdSettings.getArtifactoryAuthorizationFilePath()).thenReturn(
+                        "src/test/resources/auth/auth.txt");
         artifactoryAuthorization = new FileBasedArtifactoryAuthorizer(mockedSshdSettings);
     }
 

--- a/src/test/java/com/yahoo/sshd/server/settings/TestOptions.java
+++ b/src/test/java/com/yahoo/sshd/server/settings/TestOptions.java
@@ -114,13 +114,24 @@ public class TestOptions {
         Assert.assertEquals(fileConfiguration.getFileName(), expectedPath);
     }
 
-    @Test
-    public void testRoot() {
+    @DataProvider
+    public Object[][] roots() {
+        return new Object[][] { //
+        //
+                        {null, "src/test/resources/",}, //
+                        {"", "src/test/resources/",}, //
+                        {"    ", "src/test/resources/",}, //
+                        {" foo_root ", "foo_root/",},//
+        };
+    }
+
+    @Test(dataProvider = "roots")
+    public void testRoot(String input, String expected) {
         // we can assume ROOT is set in the env.
         // later we can play games and configure surefire to test different roots.
         // TODO: remove check for ROOT from env.
         SshdSettingsBuilder sb = new SshdSettingsBuilder();
-        Assert.assertEquals(sb.findRoot(), "src/test/resources/");
+        Assert.assertEquals(sb.findRoot(input), expected);
     }
 
     @Test

--- a/src/test/resources/developer_config/sshd_proxy.properties
+++ b/src/test/resources/developer_config/sshd_proxy.properties
@@ -1,0 +1,5 @@
+sshd.root=PWD/
+sshd.port=2222
+sshd.artifactoryUrl=http://localhost:4080/artifactory
+sshd.artifactoryUsername=user
+sshd.artifactoryPassword=password


### PR DESCRIPTION
Fixup stupid ROOT nonsense will soon remove the ROOT env var, and just use -r for root path, but we should fix the notion of how things are laid out
Add create_config.sh which set's up a properties file that tries to hit artifactory on localhost and creates a host key
Fix it to not just bail when run from the command line
Actually run from the command line
