### PR TITLE
Start on dummy shell to allow background forwarding

### DIFF
--- a/NOTES
+++ b/NOTES
@@ -1,0 +1,39 @@
+To eat the auth.
+
+
+Need to set the channelFactories:
+
+            ssh.setChannelFactories(channelFactories);
+
+
+            if (channelFactories == null) {
+                channelFactories = Arrays.asList(
+                        new ChannelSession.Factory(),
+                        new TcpipServerChannel.DirectTcpipFactory());
+            }
+
+
+Need to override TcpipServerChannel.DirectTcpipFactory and friends.
+
+Need to override the IOServiceFactory:
+org.apache.sshd.common.forward.TcpipServerChannel
+
+        connector = getSession().getFactoryManager().getIoServiceFactory()
+                .createConnector(handler);
+
+Which returns org.apache.sshd.common.io.nio2.Nio2ServiceFactory, which we need to override
+To override org.apache.sshd.common.io.nio2.Nio2Connector, which returns an org.apache.sshd.common.io.nio2.Nio2Session
+
+Which is where we can finally start eating bytes
+and worse.
+
+The bytes we need to eat may come across multiple writes, so we'll have to set a start eating and stop eating flag across peeks.
+
+This will get really Ugly because if Authorization comes as multiple packets, we'll have to buffer that bit somewhere.
+
+Basically we need to buffer at least the Authorization header:
+WWW-Authenticate: Basic realm="nmrs_m7VKmomQ2YM3:"
+
+So we need at a minimum a buffer of WWW-Authenticate: size, and if we read WWW-AuthFoo, then we can write that buffer, and the rest of the following bits, while the previous writes would have been no-ops causing latency.
+
+Worse, yet we need a secondary buffer which is looking for the \r\n\r\n ala cheap-alive, and we need to eat that and write out our auth bits.

--- a/TODO
+++ b/TODO
@@ -1,0 +1,11 @@
+
+For auth override the following are required:
+
+1. tcp port forwarding of port X to artifactory host:port.
+2. Stream sniffing, we need to read the byte from the stream stripping out any Authorization headers.
+3. Add the authorization header where it's:  ssh_user:encrypted password.
+4. encrypted password comes from encrypting a salt and the username.
+  Another option is to just pass a token, and then have an artifactory plugin verify the token
+  by connecting back to the ssh server, but that adds an extra RT.
+5. if in the same jvm 4 may change to be more secure.
+6. write a plugin to validate the password.

--- a/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsBuilder.java
+++ b/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsBuilder.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import com.yahoo.sshd.server.command.DefaultScpCommandFactory;
 import com.yahoo.sshd.server.command.DelegatingCommandFactory;
 import com.yahoo.sshd.server.jetty.JettyRunnableComponent;
+import com.yahoo.sshd.server.settings.SshdProxySettings.ShellMode;
 import com.yahoo.sshd.utils.RunnableComponent;
 
 /**
@@ -94,6 +95,8 @@ public class SshdSettingsBuilder {
 
     private Boolean developerMode;
 
+    private ShellMode shellMode;
+
     protected String overriddenRoot;
 
     static final List<String> DEFAULT_COMMAND_FACTORIES = new ArrayList<>(Arrays.asList(new String[] {//
@@ -144,6 +147,7 @@ public class SshdSettingsBuilder {
         requestLogPath = findRequestLogPath();
         httpPort = findHttpPort();
         webappsDir = findWebappDir();
+        shellMode = findShellMode();
 
         // do this last, so it can rely on everything before/
         externalComponents = createExternalComponents();
@@ -265,7 +269,6 @@ public class SshdSettingsBuilder {
         return getStringFromConfig("sshd.hostKeyPath", defaultHostKeyPath, "got host key");
     }
 
-    @SuppressWarnings("unchecked")
     List<DelegatingCommandFactory> createCfInstances() {
         List<DelegatingCommandFactory> cfInstances = new ArrayList<>();
         cfInstances.add(new DefaultScpCommandFactory());
@@ -642,5 +645,30 @@ public class SshdSettingsBuilder {
 
     public boolean getDevelopmentMode() {
         return (null == developerMode) ? false : developerMode.booleanValue();
+    }
+
+
+    /**
+     * Generate the path for where request/access logs should be written to.
+     * 
+     * @return a path to write access logs to.
+     */
+    protected ShellMode findShellMode() {
+        ShellMode defaultMode = ShellMode.MESSAGE;
+        String modeString = getStringFromConfig("sshd.shellMode", defaultMode.name(), "got ShellMode");
+        return ShellMode.valueOf(modeString);
+    }
+
+
+    public SshdSettingsBuilder setSetShellMode(ShellMode shellMode) {
+        this.shellMode = shellMode;
+        return this;
+    }
+
+    public ShellMode getShellMode() {
+        if (null == shellMode) {
+            shellMode = findShellMode();
+        }
+        return shellMode;
     }
 }

--- a/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsInterface.java
+++ b/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsInterface.java
@@ -79,7 +79,23 @@ public interface SshdSettingsInterface {
      */
     boolean isDevelopementMode();
 
+    /**
+     * 
+     * @return Factory to use for filtering.
+     */
     TcpipForwarderFactory getForwardingFactory();
 
+    /**
+     * 
+     * @return an implementation of {@link ForwardingFilter} that can be used to see if forwarding is allowed.
+     */
     ForwardingFilter getForwardingFilter();
+
+    /**
+     * This is used to determine what implementation of {@link ForwardingFilter}
+     * {@link SshdSettingsInterface#getForwardingFilter()} should return
+     * 
+     * @return
+     */
+    boolean isForwardingAllowed();
 }

--- a/src/main/java/com/yahoo/sshd/server/shell/ForwardingShellFactory.java
+++ b/src/main/java/com/yahoo/sshd/server/shell/ForwardingShellFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+/* Some portions of this code are Copyright (c) 2014, Yahoo! Inc. All rights reserved. */
+package com.yahoo.sshd.server.shell;
+
+import java.util.EnumSet;
+
+import org.apache.sshd.common.Factory;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.shell.ProcessShellFactory.TtyOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Derived from {@link org.apache.sshd.server.shell.ProcessShellFactory}.
+ * 
+ * A {@link org.apache.sshd.common.Factory<Command>} of {@link org.apache.sshd.server.Command} that will simply echo
+ * text back. The idea is to keep the shell open to allow port forwarding in the background
+ * 
+ * @author areese
+ * 
+ */
+public class ForwardingShellFactory implements Factory<Command> {
+    @SuppressWarnings("unused")
+    private static final Logger LOGGER = LoggerFactory.getLogger(ForwardingShellFactory.class);
+
+    private String[] command;
+    private EnumSet<TtyOptions> ttyOptions;
+
+    public ForwardingShellFactory(EnumSet<TtyOptions> ttyOptions) {
+        this(new String[] {}, ttyOptions);
+    }
+
+    public ForwardingShellFactory(String[] command, EnumSet<TtyOptions> ttyOptions) {
+        this.command = command;
+        this.ttyOptions = ttyOptions;
+    }
+
+    public String[] getCommand() {
+        return command;
+    }
+
+    public void setCommand(String[] command) {
+        this.command = command;
+    }
+
+    @Override
+    public Command create() {
+        return new ForwardingShellWrapper(ttyOptions);
+    }
+}

--- a/src/main/java/com/yahoo/sshd/server/shell/ForwardingShellWrapper.java
+++ b/src/main/java/com/yahoo/sshd/server/shell/ForwardingShellWrapper.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+/* Some portions of this code are Copyright (c) 2014, Yahoo! Inc. All rights reserved. */
+package com.yahoo.sshd.server.shell;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.util.EnumSet;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.sshd.common.util.ThreadUtils;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.Environment;
+import org.apache.sshd.server.ExitCallback;
+import org.apache.sshd.server.SessionAware;
+import org.apache.sshd.server.session.ServerSession;
+import org.apache.sshd.server.shell.ProcessShellFactory.TtyOptions;
+import org.apache.sshd.server.shell.Shell;
+import org.apache.sshd.server.shell.TtyFilterInputStream;
+import org.apache.sshd.server.shell.TtyFilterOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a mirror of {@link org.apache.sshd.server.shell.InvertedShellWrapper}, which doesn't have inverted streams.
+ * This is for when you are hooking a shell up to an input/outputstream consuming code block instead of launching a
+ * process.
+ * 
+ * This interface is meant to be used with {@link ForwardingShellFactory} class as an implementation of
+ * {@link org.apache.sshd.common.Factory<Command>}.
+ * 
+ * This class implements the {@link Shell} interface as an implementation of {@link org.apache.sshd.server.Command}.
+ * 
+ * whole point of this class is to have a shell that stays open and provides a way to forward traffic to artifactory
+ * without implementing any commands.
+ * 
+ * {@link Shell} is a mirror of {@link org.apache.sshd.server.shell.InvertedShell} but without the stream inversion
+ * 
+ * @author areese
+ * 
+ */
+public class ForwardingShellWrapper implements Command, SessionAware, Shell {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ForwardingShellWrapper.class);
+
+    private final Executor executor;
+    private final EnumSet<TtyOptions> ttyOptions;
+
+    private TtyFilterInputStream in;
+    private OutputStream out;
+    private OutputStream err;
+    private ExitCallback callback;
+    private final boolean shutdownExecutor;
+    private boolean alive = true;
+
+    public ForwardingShellWrapper(EnumSet<TtyOptions> ttyOptions) {
+        // TODO: fix name, we should have some way to identify where this came from.
+        this(ttyOptions, ThreadUtils.newSingleThreadExecutor("shell[" + "]"), true);
+    }
+
+    public ForwardingShellWrapper(EnumSet<TtyOptions> ttyOptions, Executor executor) {
+        this(ttyOptions, executor, false);
+    }
+
+    public ForwardingShellWrapper(EnumSet<TtyOptions> ttyOptions, Executor executor, boolean shutdownExecutor) {
+        this.ttyOptions = ttyOptions;
+        this.executor = executor;
+        this.shutdownExecutor = shutdownExecutor;
+    }
+
+    @Override
+    public void setInputStream(InputStream in) {
+        this.in = new TtyFilterInputStream(ttyOptions, in);
+    }
+
+    @Override
+    public void setOutputStream(OutputStream out) {
+        this.out = new TtyFilterOutputStream(ttyOptions, out, in);
+    }
+
+    @Override
+    public void setErrorStream(OutputStream err) {
+        this.err = new TtyFilterOutputStream(ttyOptions, err, in);
+    }
+
+    @Override
+    public void setExitCallback(ExitCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    public void setSession(ServerSession session) {
+        // TODO: do we care about session's?
+        // if (shell instanceof SessionAware) {
+        // ((SessionAware) shell).setSession(session);
+        // }
+    }
+
+    @Override
+    public synchronized void start(Environment env) throws IOException {
+        // TODO propagate the Environment itself and support signal sending.
+        executor.execute(new Runnable() {
+            @Override
+            public void run() {
+                runShell();
+            }
+        });
+        LOGGER.info("Leaving start");
+    }
+
+    @Override
+    public synchronized void destroy() {
+        if (shutdownExecutor && executor instanceof ExecutorService) {
+            ((ExecutorService) executor).shutdown();
+        }
+
+        if (null != in) {
+            try {
+                in.close();
+            } catch (IOException e) {
+                LOGGER.debug("in.close", e);
+            }
+        }
+
+        if (null != out) {
+            try {
+                out.close();
+            } catch (IOException e) {
+                LOGGER.debug("out.close", e);
+            }
+        }
+
+        if (null != err) {
+            try {
+                err.close();
+            } catch (IOException e) {
+                LOGGER.debug("err.close", e);
+            }
+        }
+    }
+
+    /**
+     * Run a shell looking for a ctrl-d.
+     */
+    protected void runShell() {
+        try {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("Running forwarding shell: in: {} out: {}  err: {}", in, out, err);
+            }
+
+            Reader r = new InputStreamReader(in);
+
+            try {
+                int c = 0;
+
+                while (alive && -1 != (c = r.read())) {
+                    switch (c) {
+                        case 0x04:
+                            LOGGER.info("leaving.");
+                            this.alive = false;
+                            return;
+
+                        default:
+                            out.write(c);
+                            out.flush();
+                            break;
+                    }
+                }
+
+                out.flush();
+                err.flush();
+            } catch (Exception e) {
+                e.printStackTrace();
+                this.alive = false;
+            }
+
+            out.flush();
+            err.flush();
+            return;
+        } catch (Exception e) {
+            destroy();
+        } finally {
+            callback.onExit(exitValue());
+            this.alive = false;
+            destroy();
+        }
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return in;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return out;
+    }
+
+    @Override
+    public OutputStream getErrorStream() {
+        return err;
+    }
+
+    @Override
+    public boolean isAlive() {
+        return alive;
+    }
+
+    @Override
+    public int exitValue() {
+        // TODO Auto-generated method stub
+        return 0;
+    }
+}

--- a/src/main/java/com/yahoo/sshd/server/shell/MessageShellFactory.java
+++ b/src/main/java/com/yahoo/sshd/server/shell/MessageShellFactory.java
@@ -36,14 +36,13 @@ import com.yahoo.sshd.utils.streams.EmptyInputStream;
 import com.yahoo.sshd.utils.streams.EmptyOutputStream;
 import com.yahoo.sshd.utils.streams.MessageOutputStream;
 
-/**
- * A {@link Factory} of {@link Command} that will create a new process and bridge the streams.
- * 
- * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
- */
 
 /**
- * Derived from ProcessShellFactory When someone ssh's in this should display a configurable message.
+ * Derived from {@link org.apache.sshd.server.shell.ProcessShellFactory}.
+ * 
+ * A {@link org.apache.sshd.common.Factory<Command>} of {@link org.apache.sshd.server.Command} that will display a
+ * configurable message.
+ * 
  * 
  * The message is displayed by the MessageOutputStream, but this factory takes care of reading the file and caching the
  * string.
@@ -94,6 +93,7 @@ public class MessageShellFactory extends ProcessShellFactory {
         return new MessageShell();
     }
 
+    // FIXME: probably doesn't need to extend ProcessShell, or InvertedShell,
     final class MessageShell extends ProcessShell implements InvertedShell, Runnable {
         private final TtyFilterOutputStream in;
         private final TtyFilterInputStream out;

--- a/src/main/java/com/yahoo/sshd/tools/artifactory/ArtifactoryInformation.java
+++ b/src/main/java/com/yahoo/sshd/tools/artifactory/ArtifactoryInformation.java
@@ -12,6 +12,9 @@
  */
 package com.yahoo.sshd.tools.artifactory;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.jfrog.artifactory.client.ning.NingRequest;
 
 import com.ning.http.client.AsyncHttpClient.BoundRequestBuilder;
@@ -33,13 +36,21 @@ import com.yahoo.sshd.server.settings.SshdProxySettings;
  */
 public class ArtifactoryInformation {
     private final String artifactoryUrl;
+    private final String artifactoryHost;
+    private final int artifactoryPort;
     private final String artifactoryUsername;
     private final char[] artifactoryPassword;
 
-    public ArtifactoryInformation(String artifactoryUrl, String artifactoryUsername, String artifactoryPassword) {
+    public ArtifactoryInformation(String artifactoryUrl, String artifactoryUsername, String artifactoryPassword)
+                    throws MalformedURLException {
         this.artifactoryUrl = artifactoryUrl;
         this.artifactoryUsername = artifactoryUsername;
         this.artifactoryPassword = (null != artifactoryPassword) ? artifactoryPassword.toCharArray() : null;
+
+        // need to parse the url to get the host and port.
+        URL url = new URL(artifactoryUrl);
+        artifactoryHost = url.getHost();
+        artifactoryPort = url.getPort();
     }
 
     public String getArtifactoryUrl() {
@@ -52,6 +63,14 @@ public class ArtifactoryInformation {
 
     public char[] getArtifactoryPassword() {
         return artifactoryPassword;
+    }
+
+    public String getArtifactoryHost() {
+        return artifactoryHost;
+    }
+
+    public int getArtifactoryPort() {
+        return artifactoryPort;
     }
 
     @Override
@@ -101,7 +120,7 @@ public class ArtifactoryInformation {
     }
 
     /**
-     * Override this to return a NingRequest that automatically adds headers or any other informatnion you need to pass.
+     * Override this to return a NingRequest that automatically adds headers or any other information you need to pass.
      * 
      * @return
      */
@@ -110,7 +129,7 @@ public class ArtifactoryInformation {
     }
 
     /**
-     * If you need to pass other headers or cookies to artifactory you'll want to sublcass this, and have
+     * If you need to pass other headers or cookies to artifactory you'll want to subclass this, and have
      * {@link ArtifactoryInformation#createNingRequest()} return an instance of your subclass
      * 
      * @author areese

--- a/src/main/java/org/apache/sshd/server/shell/Shell.java
+++ b/src/main/java/org/apache/sshd/server/shell/Shell.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+/* Some portions of this code are Copyright (c) 2014, Yahoo! Inc. All rights reserved. */
+package org.apache.sshd.server.shell;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.apache.sshd.server.Environment;
+
+import com.yahoo.sshd.server.shell.ForwardingShellWrapper;
+
+/**
+ * This is a mirror of {@link org.apache.sshd.server.shell.InvertedShell}, which doesn't have inverted streams. This is
+ * for when you are hooking a shell up to an input/outputstream consuming code block instead of launching a process.
+ * 
+ * This interface is meant to be used with {@link ForwardingShellWrapper} class as an implementation of
+ * {@link org.apache.sshd.common.Factory<Command>}.
+ * 
+ * @author <a href="mailto:dev@mina.apache.org">Apache MINA SSHD Project</a>
+ * @author areese
+ */
+public interface Shell {
+
+    /**
+     * Starts the shell and will make the streams available for the ssh server to retrieve and use.
+     * 
+     * @param env
+     * @throws Exception
+     */
+    void start(Environment env) throws IOException;
+
+    /**
+     * Returns the input stream used to feed the shell. This method is called after the shell has been started.
+     * 
+     * @return
+     */
+    InputStream getInputStream();
+
+    /**
+     * Return an OuputStream representing the output stream of the shell.
+     * 
+     * @return
+     */
+    OutputStream getOutputStream();
+
+    /**
+     * Return an InputStream representing the error stream of the shell.
+     * 
+     * @return
+     */
+    OutputStream getErrorStream();
+
+    /**
+     * Check if the underlying shell is still alive
+     * 
+     * @return
+     */
+    boolean isAlive();
+
+    /**
+     * Retrieve the exit value of the shell. This method must only be called when the shell is not alive anymore.
+     * 
+     * @return the exit value of the shell
+     */
+    int exitValue();
+
+    /**
+     * Destroy the shell. This method can be called by the SSH server to destroy the shell because the client has
+     * disconnected somehow.
+     */
+    void destroy();
+}

--- a/src/main/java/org/apache/sshd/server/shell/TtyFilterInputStream.java
+++ b/src/main/java/org/apache/sshd/server/shell/TtyFilterInputStream.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+/* Some portions of this code are Copyright (c) 2014, Yahoo! Inc. All rights reserved. */
+package org.apache.sshd.server.shell;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.EnumSet;
+
+import org.apache.sshd.common.util.Buffer;
+import org.apache.sshd.server.shell.ProcessShellFactory.TtyOptions;
+
+/**
+ * From: {@link org.apache.sshd.server.shell.ProcessShellFactory}, but extracted so we can use them without subclassing.
+ * 
+ * @author areese
+ * 
+ */
+public class TtyFilterInputStream extends FilterInputStream {
+    private Buffer buffer;
+    private int lastChar;
+    private final EnumSet<TtyOptions> ttyOptions;
+
+    public TtyFilterInputStream(EnumSet<TtyOptions> ttyOptions, InputStream in) {
+        super(in);
+        buffer = new Buffer(32);
+        this.ttyOptions = ttyOptions;
+    }
+
+    synchronized void write(int c) {
+        buffer.putByte((byte) c);
+    }
+
+    synchronized void write(byte[] buf, int off, int len) {
+        buffer.putBytes(buf, off, len);
+    }
+
+    @Override
+    public int available() throws IOException {
+        return super.available() + buffer.available();
+    }
+
+    @Override
+    public synchronized int read() throws IOException {
+        int c;
+        if (buffer.available() > 0) {
+            c = buffer.getByte();
+            buffer.compact();
+        } else {
+            c = super.read();
+        }
+        if (c == '\n' && ttyOptions.contains(TtyOptions.ONlCr) && lastChar != '\r') {
+            c = '\r';
+            Buffer buf = new Buffer();
+            buf.putByte((byte) '\n');
+            buf.putBuffer(buffer);
+            buffer = buf;
+        } else if (c == '\r' && ttyOptions.contains(TtyOptions.OCrNl)) {
+            c = '\n';
+        }
+        lastChar = c;
+        return c;
+    }
+
+    @Override
+    public synchronized int read(byte[] b, int off, int len) throws IOException {
+        if (buffer.available() == 0) {
+            int nb = super.read(b, off, len);
+            buffer.putRawBytes(b, off, nb);
+        }
+        int nb = 0;
+        while (nb < len && buffer.available() > 0) {
+            b[off + nb++] = (byte) read();
+        }
+        return nb;
+    }
+}

--- a/src/main/java/org/apache/sshd/server/shell/TtyFilterOutputStream.java
+++ b/src/main/java/org/apache/sshd/server/shell/TtyFilterOutputStream.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+/* Some portions of this code are Copyright (c) 2014, Yahoo! Inc. All rights reserved. */
+package org.apache.sshd.server.shell;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.EnumSet;
+
+import org.apache.sshd.server.shell.ProcessShellFactory.TtyOptions;
+
+
+/**
+ * From: {@link org.apache.sshd.server.shell.ProcessShellFactory}, but extracted so we can use them without subclassing.
+ * 
+ * org.apache.sshd.server.shell.ProcessShellFactory does this: ttyOptions = EnumSet.of(TtyOptions.ONlCr);
+ * 
+ * However, it doesn't seem to work for me. So in our copy of
+ * org.apache.sshd.server.shell.TtyFilterOutputStream.TtyFilterOutputStream(EnumSet<TtyOptions>, OutputStream,
+ * TtyFilterInputStream), we have a special hack that if TtyOptions.INlCr and TtyOptions.ICrNl are both set, send cr nl
+ * instead. no idea if the windows even works.
+ * 
+ * So in here, we have a special hack.. gack.
+ * 
+ * @author areese
+ * 
+ */
+public class TtyFilterOutputStream extends FilterOutputStream {
+    private final TtyFilterInputStream echo;
+    private final EnumSet<TtyOptions> ttyOptions;
+
+    public TtyFilterOutputStream(EnumSet<TtyOptions> ttyOptions, OutputStream out, TtyFilterInputStream echo) {
+        super(out);
+        this.echo = echo;
+        this.ttyOptions = ttyOptions;
+    }
+
+    @Override
+    public void write(int c) throws IOException {
+
+        /**
+         * special hack, because I can't seem to get ssh output to work write. without the \r\n on os-x and rhel6, the
+         * terminal doesn't start on a newline. it just eats it, and starts again on the same line. need to test on a
+         * non-OS-X terminal
+         */
+        if (c == '\n' && ttyOptions.contains(TtyOptions.INlCr) && ttyOptions.contains(TtyOptions.ICrNl)) {
+            super.write('\r');
+            super.write('\n');
+        } else {
+            if (c == '\n' && ttyOptions.contains(TtyOptions.INlCr)) {
+                c = '\r';
+            } else if (c == '\r' && ttyOptions.contains(TtyOptions.ICrNl)) {
+                c = '\n';
+            }
+            super.write(c);
+        }
+
+        if (ttyOptions.contains(TtyOptions.Echo) && null != echo) {
+            echo.write(c);
+        }
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        for (int i = off; i < len; i++) {
+            write(b[i]);
+        }
+    }
+}

--- a/src/test/java/com/yahoo/sshd/server/settings/TestChainedFactories.java
+++ b/src/test/java/com/yahoo/sshd/server/settings/TestChainedFactories.java
@@ -15,9 +15,7 @@ package com.yahoo.sshd.server.settings;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.sshd.server.Command;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -57,7 +55,7 @@ public class TestChainedFactories {
         }
 
         SshdSettingsInterface sshdSettings =
-                        new SshdSettingsBuilder().setSshdPort(2222).setConfiguration(Mockito.mock(Configuration.class))
+                        new SshdSettingsBuilder().setSshdPort(2222).setConfiguration(Utils.getConfigMock())
                                         .setArtifactoryUsername("a").setArtifactoryPassword("password")
                                         .setArtifactoryUrl("http://your:4080/artifactory").setCommandFactories(cfList)
                                         .build();

--- a/src/test/java/com/yahoo/sshd/server/settings/TestCipherFactories.java
+++ b/src/test/java/com/yahoo/sshd/server/settings/TestCipherFactories.java
@@ -15,10 +15,8 @@ package com.yahoo.sshd.server.settings;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.sshd.common.Cipher;
 import org.apache.sshd.common.NamedFactory;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,7 +31,7 @@ public class TestCipherFactories {
         // arcfour's aren't working on 7u45
 
         SshdSettingsInterface settings =
-                        new SshdSettingsBuilder().setSshdPort(2222).setConfiguration(Mockito.mock(Configuration.class))
+                        new SshdSettingsBuilder().setSshdPort(2222).setConfiguration(Utils.getConfigMock())
                                         .setArtifactoryUsername("a").setArtifactoryPassword("password")
                                         .setArtifactoryUrl("http://your:4080/artifactory")
                                         .setCommandFactories(Collections.<DelegatingCommandFactory>emptyList()).build();

--- a/src/test/java/com/yahoo/sshd/server/settings/Utils.java
+++ b/src/test/java/com/yahoo/sshd/server/settings/Utils.java
@@ -1,0 +1,244 @@
+package com.yahoo.sshd.server.settings;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.configuration.Configuration;
+
+public class Utils {
+    public static Configuration getConfigMock() {
+        return new Configuration() {
+
+            @Override
+            public Configuration subset(String prefix) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public void setProperty(String key, Object value) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public boolean isEmpty() {
+                // TODO Auto-generated method stub
+                return false;
+            }
+
+            @Override
+            public String[] getStringArray(String key) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public String getString(String key, String defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public String getString(String key) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public Short getShort(String key, Short defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public short getShort(String key, short defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public short getShort(String key) {
+                // TODO Auto-generated method stub
+                return 0;
+            }
+
+            @Override
+            public Object getProperty(String key) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public Properties getProperties(String key) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public Long getLong(String key, Long defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public long getLong(String key, long defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public long getLong(String key) {
+                // TODO Auto-generated method stub
+                return 0;
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public List<Object> getList(String key, List<?> defaultValue) {
+                return (List<Object>) defaultValue;
+            }
+
+            @Override
+            public List<Object> getList(String key) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public Iterator<String> getKeys(String prefix) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public Iterator<String> getKeys() {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public Integer getInteger(String key, Integer defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public int getInt(String key, int defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public int getInt(String key) {
+                // TODO Auto-generated method stub
+                return 0;
+            }
+
+            @Override
+            public Float getFloat(String key, Float defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public float getFloat(String key, float defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public float getFloat(String key) {
+                // TODO Auto-generated method stub
+                return 0;
+            }
+
+            @Override
+            public Double getDouble(String key, Double defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public double getDouble(String key, double defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public double getDouble(String key) {
+                // TODO Auto-generated method stub
+                return 0;
+            }
+
+            @Override
+            public Byte getByte(String key, Byte defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public byte getByte(String key, byte defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public byte getByte(String key) {
+                // TODO Auto-generated method stub
+                return 0;
+            }
+
+            @Override
+            public Boolean getBoolean(String key, Boolean defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public boolean getBoolean(String key, boolean defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public boolean getBoolean(String key) {
+                // TODO Auto-generated method stub
+                return false;
+            }
+
+            @Override
+            public BigInteger getBigInteger(String key, BigInteger defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public BigInteger getBigInteger(String key) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public BigDecimal getBigDecimal(String key, BigDecimal defaultValue) {
+                return defaultValue;
+            }
+
+            @Override
+            public BigDecimal getBigDecimal(String key) {
+                // TODO Auto-generated method stub
+                return null;
+            }
+
+            @Override
+            public boolean containsKey(String key) {
+                // TODO Auto-generated method stub
+                return false;
+            }
+
+            @Override
+            public void clearProperty(String key) {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void clear() {
+                // TODO Auto-generated method stub
+
+            }
+
+            @Override
+            public void addProperty(String key, Object value) {
+                // TODO Auto-generated method stub
+            }
+        };
+    }
+}


### PR DESCRIPTION
We don't use ssh to deploy right now

 * special hack, because I can't seem to get ssh output to work write. without the \r\n on os-x and rhel6, the
 * terminal doesn't start on a newline. it just eats it, and starts again on the same line. need to test on a
 * non-OS-X terminal

Fix to use an enum to pick the shell mode

Rework the layout of the forwarding filtering
Add further tests for forwarding
Add restrictions to prevent forwarding to hosts other than the artifactory host
organize imports
update notes

Cleanup javadocs

Cleanup Shell