### PR TITLE
Travis makes releases into bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
 language: java
+
 jdk:
-    - oraclejdk7
+  - oraclejdk7
+
+after_success:
+  - test "${TRAVIS_PULL_REQUEST}" == "false" && test "${TRAVIS_TAG}" != "" && test "${TRAVIS_BRANCH}" == "master" && ./travis/publish_to_bintray.sh
+
+branches:
+  except:
+    - travis
+    - gh-pages
+
+env:
+  global:
+  - secure: crAehoZ8wBdKnTqLTaeCcesaNVmEpTXtkkrqKzJHQv68oUWhaAXCxyBouH7LeIEVqyoGLuoD+ktQYWAZ5IKLghWIU90LoltP7tLpEE4uZegAoTneayQBfqxkTNaToX+aUiKsceO7mBKy9elC+Pt1N/euVlrUFqQ8J6EsF3/W6ek=
+  - secure: Jn7t5oIyyacBw87tYuDB0R7ZhS2SicaorafCHQ2qCZn/uANS7iwijjYV01ruh6Pw6lh0RJGvNE7+4Yu+QxDgvxiymyvDLOEM3fQXATfDOrBx9dxoOPjnMBaE3mffdXRkhEIHrGWgsLRCL4hu8/RahAj+xhd75t71V/C0Tt69keo=

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <packaging>jar</packaging>
 
     <scm>
-        <developerConnection>scm:git:ssh://git@github.com:yahoo/artifactory_ssh_proxy.git</developerConnection>
+        <developerConnection>scm:git:ssh://git@github.com/yahoo/artifactory_ssh_proxy.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 
@@ -75,6 +75,11 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.2</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/travis/publish_to_bintray.sh
+++ b/travis/publish_to_bintray.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2015 Yahoo! Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO: Once https://github.com/travis-ci/dpl/pull/259 is merged,
+#       remove this script and use the provider.
+
+# Simple script to use from Travis-CI that will push out a jar to
+# bintray maven repository.  This script should be ran from the travis
+# machine, and specified to be used in the yml build configuration.
+set -e
+echo "Publishing to bintray at https://bintray.com/yahoo"
+
+CURRENT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)')
+echo "Releasing version:  ${CURRENT_VERSION}"
+
+ARTIFACTS=( sshd_proxy-${CURRENT_VERSION}.jar sshd_proxy-${CURRENT_VERSION}-site.jar )
+
+# Upload and Publish each artifact into bintray
+# https://bintray.com/yahoo/maven/artifactory_ssh_proxy/view
+for artifact in "${ARTIFACTS[@]}"
+do
+    echo "Uploading $artifact..."
+    UPLOAD_RESPONSE=curl -s -o /dev/null -w "%{http_code}" -T target/$artifact -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/yahoo/maven/artifactory_ssh_proxy/${CURRENT_VERSION}/${CURRENT_VERSION}/${ARTIFACT}
+    if (( $UPLOAD_RESPONSE >= 200 && $UPLOAD_RESPONSE < 227 )); then
+        echo "Success Uploading $artifact."
+        echo
+    else
+        echo "Error during upload: HTTP $UPLOAD_RESPONSE"
+        echo
+        exit 1
+    fi
+    echo
+done
+
+echo "Publishing Version ${CURRENT_VERSION} of artifactory_ssh_proxy"
+PUBLISH_RESPONSE=curl -s -o /dev/null -w "%{http_code}" -X POST -u ${BINTRAY_USER}:${BINTRAY_API_KEY} https://api.bintray.com/content/yahoo/maven/artifactory_ssh_proxy/${CURRENT_VERSION}/publish
+if (( $PUBLISH_RESPONSE >= 200 && $PUBLISH_RESPONSE < 227 )); then
+    echo "Success publishing."
+    echo "https://bintray.com/yahoo/maven/artifactory_ssh_proxy/${CURRENT_VERSION}/view"
+    echo
+else
+    echo "Error during publishing ${CURRENT_VERSION} of artifactory_ssh_proxy."
+    echo "HTTP ${PUBLISH_RESPONSE}"
+    exit 1
+fi
+echo


### PR DESCRIPTION
- For releases, use maven release from your local dev box.  Travis will
  pick up the tag on it's run, and make the right pushes into bintray.

@areese we need to test this once it's in.  I've done some amount of testing on my user account's bintray, but this is now yahoo-org.