### PR TITLE
Update dependencies: mina, jackson, & others

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mina.version>2.0.7</mina.version>
+        <mina.version>2.0.9</mina.version>
         <checkstyle.skip>false</checkstyle.skip>
         <min_jdk_version>1.7</min_jdk_version>
         <min_maven_version>2.1</min_maven_version>
@@ -301,7 +301,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.2.3</version>
+                <version>2.5.3</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
@@ -336,22 +336,22 @@
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-core</artifactId>
-                <version>1.0.13</version>
+                <version>1.1.3</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>
                 <artifactId>logback-classic</artifactId>
-                <version>1.0.13</version>
+                <version>1.1.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.2.3</version>
+                <version>2.5.3</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.2.3</version>
+                <version>2.5.3</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.nekohtml</groupId>
@@ -361,7 +361,7 @@
             <dependency>
                 <groupId>javassist</groupId>
                 <artifactId>javassist</artifactId>
-                <version>3.11.0.GA</version>
+                <version>3.12.1.GA</version>
             </dependency>
             <!--  fixed by https://github.com/JFrogDev/artifactory-client-java/pull/51/ -->
             <dependency>
@@ -451,7 +451,7 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- Update mina from 2.0.7 to 2.0.9
- Update jackson from 2.2.3 to 2.5.3
- Update logback from 1.0.13 to 1.1.3
- Update javassist from 3.11.0.GA to 3.12.1.GA
- Update commons-cli from 1.2 to 1.3