### PR TITLE
Added flag to serve VIP and/or artifactory.war

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ With these instructions, you can copy the artifactory war to
 The sshd proxy embeds jetty to allow custom functionality.
 If you have a vip that performs status checks over http, you can use jetty to communicate back to the vip.
 
+To switch on the vip mode in jetty use the parameter '-s vip'. This will serve the resources in the configured webapp directory.
+To deploy the artifactory.war, use '-s artifactory'. To do both, use '-s both'. If this flag is not supplied, it defaults to '-s artifactory'.
+
 If you are running multiple instances of the proxy behind a vip, you'll want to ensure that the host keys
 of all hosts that are behind the vip match.
 

--- a/src/main/java/com/yahoo/sshd/server/jetty/JettyRunnableComponent.java
+++ b/src/main/java/com/yahoo/sshd/server/jetty/JettyRunnableComponent.java
@@ -20,18 +20,21 @@ import com.yahoo.sshd.utils.RunnableComponent;
 
 /**
  * A wrapper to allow jetty to be started and stopped.
- * 
+ *
  * @author areese
- * 
+ *
  */
 public class JettyRunnableComponent implements RunnableComponent {
 
     private int jettyPort;
     private String jettyWebAppDir;
     private Server server;
+    private JettyServiceSetting jettyServiceSetting;
 
-    public JettyRunnableComponent(final int jettyPort, final String jettyWebAppDir) {
+    public JettyRunnableComponent(final int jettyPort, final String jettyWebAppDir,
+                                  final JettyServiceSetting jettyServiceSetting) {
         this.jettyPort = jettyPort;
+        this.jettyServiceSetting = jettyServiceSetting;
         this.jettyWebAppDir = (null == jettyWebAppDir) ? null : jettyWebAppDir.trim();
     }
 
@@ -42,7 +45,7 @@ public class JettyRunnableComponent implements RunnableComponent {
                 return;
             }
 
-            server = JettyServer.newServer(jettyPort, jettyWebAppDir);
+            server = JettyServer.newServer(jettyPort, jettyWebAppDir, jettyServiceSetting);
             server.start();
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/main/java/com/yahoo/sshd/server/jetty/JettyServiceSetting.java
+++ b/src/main/java/com/yahoo/sshd/server/jetty/JettyServiceSetting.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Yahoo! Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an AS IS BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.yahoo.sshd.server.jetty;
+
+
+/**
+ * Used to tell the Jetty server which resources to serve.
+ *
+ * @author muellerfabian
+ *
+ */
+public enum JettyServiceSetting {
+
+    ARTIFACTORY,
+    VIP,
+    BOTH;
+
+
+    public static JettyServiceSetting valueOfIgnoreCase(String setting) throws IllegalArgumentException{
+
+        if (null != setting) {
+            setting = setting.toUpperCase();
+        }
+
+        return JettyServiceSetting.valueOf(setting);
+    }
+
+}

--- a/src/test/java/com/yahoo/sshd/server/jetty/TestJettyRunnable.java
+++ b/src/test/java/com/yahoo/sshd/server/jetty/TestJettyRunnable.java
@@ -32,7 +32,7 @@ public class TestJettyRunnable {
 
     @Test(dataProvider = "disabled")
     public void testDisabled(int port, String webapp) throws Exception {
-        RunnableComponent rc = new JettyRunnableComponent(port, webapp);
+        RunnableComponent rc = new JettyRunnableComponent(port, webapp, JettyServiceSetting.ARTIFACTORY);
         rc.run();
         rc.close();
     }
@@ -40,7 +40,7 @@ public class TestJettyRunnable {
     // FIXME: figure out how to get a dynamic port, I made this one up.
     @Test
     public void test() throws Exception {
-        RunnableComponent rc = new JettyRunnableComponent(60540, "target/webapps");
+        RunnableComponent rc = new JettyRunnableComponent(60540, "target/webapps", JettyServiceSetting.ARTIFACTORY);
         rc.run();
         rc.close();
     }


### PR DESCRIPTION
 - Added flag '-s' to configure jetty's serving mode
 - '-s vip' serves the resources in the webapp directory
 - '-s artifactory' deploys the artifactory.war in the webapp directory
 - '-s both' does both of the above
 - if the flag is not supplied it defaults to only serve the
   artifactory.war
 - if the flag parameter is invalid the SshdSettingsBuilder exits with
   an exception.