### PR TITLE
Fix thread leak happens in the downloading and uploading 

### DIFF
--- a/src/main/java/com/yahoo/sshd/server/command/ScpCommandSessionListener.java
+++ b/src/main/java/com/yahoo/sshd/server/command/ScpCommandSessionListener.java
@@ -1,0 +1,46 @@
+package com.yahoo.sshd.server.command;
+
+import org.apache.sshd.common.Session;
+import org.apache.sshd.common.SessionListener;
+import org.apache.sshd.server.session.ServerSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is used to monitor the session close event for a ScpCommand Object so that it can clean up the ScpCommand
+ * when the session is closed.
+ *
+ * @author adam701 on 9/29/15.
+ */
+public class ScpCommandSessionListener implements SessionListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScpCommandSessionListener.class);
+    private final Thread threadRunningScpCommand;
+
+    public ScpCommandSessionListener(final Thread threadRunningScpCommand) {
+        this.threadRunningScpCommand = threadRunningScpCommand;
+    }
+
+    public void registerSession(ServerSession session) {
+        session.addListener(this);
+    }
+
+    @Override
+    public void sessionCreated(Session session) {
+    }
+
+    @Override
+    public void sessionEvent(Session session, Event event) {
+    }
+
+    @Override
+    public void sessionClosed(Session session) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Session is closed. Try to interrupt the downloading thread if it is still blocked.");
+        }
+
+        if (null != this.threadRunningScpCommand) {
+            this.threadRunningScpCommand.interrupt();
+        }
+    }
+}

--- a/src/main/java/com/yahoo/sshd/tools/artifactory/JFrogArtifactoryClientHelper.java
+++ b/src/main/java/com/yahoo/sshd/tools/artifactory/JFrogArtifactoryClientHelper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -191,8 +192,9 @@ public class JFrogArtifactoryClientHelper {
         return in;
     }
 
-    public void putArtifact(PipedInputStream snk, String filePath, Map<String, Object> properties, AsyncHandler handler)
-                    throws ArtifactNotFoundException, IOException {
+    public Future<Void> putArtifact(PipedInputStream snk, String filePath, Map<String, Object> properties,
+                                    AsyncHandler handler)
+        throws ArtifactNotFoundException, IOException {
         try {
             couldThrowIOException();
             final UploadableArtifact upload = repository.upload(filePath, snk);
@@ -204,9 +206,12 @@ public class JFrogArtifactoryClientHelper {
             }
             // We can't block here because we need to call outputstream.close() which happens outside of this method. So
             // are using handler to handle it.
-            CACHED_THREAD_POOL.submit(getUploader(upload, handler));
+            return CACHED_THREAD_POOL.submit(getUploader(upload, handler));
         } catch (IOException ex) {
             handleIOException(ex);
+
+            // This statement is not reachable since the handleIOException will rethrow the exception.
+            return null;
         }
     }
 

--- a/src/test/java/com/yahoo/sshd/server/command/TestScpCommandSessionListener.java
+++ b/src/test/java/com/yahoo/sshd/server/command/TestScpCommandSessionListener.java
@@ -1,0 +1,46 @@
+package com.yahoo.sshd.server.command;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test the ScpCommandSessionListener
+ *
+ * Created by adam701 on 9/30/15.
+ *
+ */
+public class TestScpCommandSessionListener {
+
+    @Test
+    public void testSessionCloseInterruptThread() throws InterruptedException {
+        RunnableWithInterruptedFlag blockedTask = new RunnableWithInterruptedFlag();
+
+        Thread thread = Executors.defaultThreadFactory().newThread(blockedTask);
+        thread.start();
+
+        ScpCommandSessionListener scpCommandSessionListener = new ScpCommandSessionListener(thread);
+        scpCommandSessionListener.sessionClosed(null);
+        thread.join(100000);
+
+        Assert.assertEquals(blockedTask.interrupt, true, "Session close event should interrupt the thread.");
+    }
+
+    private class RunnableWithInterruptedFlag implements Runnable {
+
+        boolean interrupt = false;
+
+        @Override
+        public void run() {
+            try {
+                TimeUnit.SECONDS.sleep(20);
+            } catch (InterruptedException e) {
+                this.interrupt = true;
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
The thread leak may happen when the client session is timed out but the request between sshd proxy and artifactory is still blocked.

To fix this issue:

Added the session listener for the ScpCommand so that the session close method can interrupt the blocked ScpCommand thread. 

Also implemented the handleClose method for the ArtifactorySshFile so that the uploader thread can be cancelled when the session is closed.