### PR TITLE
Update groovy-all for CVE-2015-3253 Vuln

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
         <dependency>
             <artifactId>groovy-all</artifactId>
             <groupId>org.codehaus.groovy</groupId>
-            <version>2.3.2</version>
+            <version>2.4.5</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
 - Update to a version not affected by
   http://seclists.org/oss-sec/2015/q3/121
 - 2.4.5 is the latest version as of this commit.