### PR TITLE
Fixed publish script grep regex

### DIFF
--- a/travis/publish_to_bintray.sh
+++ b/travis/publish_to_bintray.sh
@@ -37,7 +37,7 @@ fi
 
 echo "Publishing to bintray at https://bintray.com/yahoo"
 
-CURRENT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|Download\w+:)')
+CURRENT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -E '(^\d+\.\d+\.\d+)')
 echo "Releasing version:  ${CURRENT_VERSION}"
 
 # Some initial setup to get the right files in the right location for us


### PR DESCRIPTION
 - The publish script failed due to problems with grepping the version.
 - The new grep regex explicitly greps versions instead of using
   inverted matches.