### PR TITLE
support multiple hostkeys

### DIFF
--- a/src/main/java/com/yahoo/sshd/server/SshServerWrapper.java
+++ b/src/main/java/com/yahoo/sshd/server/SshServerWrapper.java
@@ -72,7 +72,7 @@ public class SshServerWrapper implements Runnable, Closeable {
                         .artifactoryAuthorizerProvider(this.settings));
         this.keyPairProvider =
                         injector.getInstance(PEMHostKeyProviderFactory.class).createPEMHostKeyProvider(
-                                        this.settings.getHostKeyPath());
+                                        this.settings.getHostKeyPaths());
         this.requestLog =
                         injector.getInstance(RequestLogFactory.class).createRequestLog(
                                         this.settings.getRequestLogPath());

--- a/src/main/java/com/yahoo/sshd/server/settings/SshdProxySettings.java
+++ b/src/main/java/com/yahoo/sshd/server/settings/SshdProxySettings.java
@@ -95,9 +95,9 @@ public class SshdProxySettings implements SshdSettingsInterface {
     protected final int httpPort;
 
     /**
-     * The path to the host key the server uses
+     * The paths to the host key the server uses
      */
-    protected final String hostKeyPath;
+    protected final List<String> hostKeyPaths;
 
     /**
      * An odd hackery to allow the CommandFactories to be changed while doing development TODO: remove/refactor out.
@@ -134,7 +134,7 @@ public class SshdProxySettings implements SshdSettingsInterface {
 
         this.port = b.getSshdPort();
         this.httpPort = b.getHttpPort();
-        this.hostKeyPath = b.getHostKeyPath();
+        this.hostKeyPaths = b.getHostKeyPaths();
         this.cfInstances = Collections.unmodifiableList(b.getCommandFactories());
 
         String artifactoryUrl = b.getArtifactoryUrl();
@@ -207,11 +207,11 @@ public class SshdProxySettings implements SshdSettingsInterface {
     /*
      * (non-Javadoc)
      * 
-     * @see com.yahoo.sshd.server.SshdSettingsInterface#getHostKeyPath()
+     * @see com.yahoo.sshd.server.SshdSettingsInterface#getHostKeyPaths()
      */
     @Override
-    public String getHostKeyPath() {
-        return hostKeyPath;
+    public List<String> getHostKeyPaths() {
+        return hostKeyPaths;
     }
 
     /*

--- a/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsBuilder.java
+++ b/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsBuilder.java
@@ -87,7 +87,7 @@ public class SshdSettingsBuilder {
     private int httpPort;
     private String webappsDir;
     private JettyServiceSetting jettyServiceSetting;
-    private String hostKeyPath;
+    private List<String> hostKeyPaths;
     private String rootPath;
 
     private List<? extends DelegatingCommandFactory> commandFactories;
@@ -150,7 +150,7 @@ public class SshdSettingsBuilder {
         }
 
         rootPath = findRoot(overriddenRoot);
-        hostKeyPath = findHostKeyPath();
+        hostKeyPaths = findHostKeyPaths();
         sshdPort = findSshdPort();
         artifactoryUrl = findArtifactoryUrl();
         artifactoryUsername = findArtifactoryUsername();
@@ -297,13 +297,13 @@ public class SshdSettingsBuilder {
     /**
      * Locate the hostkey path from the configuration
      * 
-     * @return the hostKeyPath that should be set in the build for consumption by the {@link SshdSettingsInterface}
+     * @return the hostKeyPaths that should be set in the build for consumption by the {@link SshdSettingsInterface}
      *         implementation
      */
-    protected String findHostKeyPath() {
-        final String defaultHostKeyPath = getConfDir() + "ssh_host_dsa_key";
+    protected List<String> findHostKeyPaths() {
+        List<String> defaultHostKeyPaths = Arrays.asList(getConfDir() + "ssh_host_dsa_key");
 
-        return getStringFromConfig("sshd.hostKeyPath", defaultHostKeyPath, "got host key");
+        return getStringListFromConfig("sshd.hostKeyPath", defaultHostKeyPaths, "got host key");
     }
 
     List<DelegatingCommandFactory> createCfInstances() {
@@ -514,15 +514,15 @@ public class SshdSettingsBuilder {
         return this;
     }
 
-    protected String getHostKeyPath() {
-        if (null == hostKeyPath) {
-            hostKeyPath = findHostKeyPath();
+    protected List<String> getHostKeyPaths() {
+        if (null == hostKeyPaths) {
+            hostKeyPaths = findHostKeyPaths();
         }
-        return hostKeyPath;
+        return hostKeyPaths;
     }
 
-    protected SshdSettingsBuilder setHostKeyPath(String hostKeyPath) {
-        this.hostKeyPath = hostKeyPath;
+    protected SshdSettingsBuilder setHostKeyPath(List<String> hostKeyPaths) {
+        this.hostKeyPaths = hostKeyPaths;
         return this;
     }
 
@@ -667,6 +667,19 @@ public class SshdSettingsBuilder {
             return s.trim();
         }
         return s;
+    }
+
+    public List<String> getStringListFromConfig(String config, List<String> defaultValue, String message) {
+        final List<Object> list = configuration.getList("sshd.hostKeyPath", defaultValue);
+
+        List<String> ret = new ArrayList<String>();
+        for (Object o : list) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("{} {}", message, o);
+            }
+            ret.add(o.toString().trim());
+        }
+        return ret;
     }
 
 

--- a/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsInterface.java
+++ b/src/main/java/com/yahoo/sshd/server/settings/SshdSettingsInterface.java
@@ -35,7 +35,7 @@ public interface SshdSettingsInterface {
      */
     int getPort();
 
-    String getHostKeyPath();
+    List<String> getHostKeyPaths();
 
     DelegatingCommandFactory getCommandFactory();
 

--- a/src/main/java/org/apache/sshd/server/keyprovider/PEMHostKeyProvider.java
+++ b/src/main/java/org/apache/sshd/server/keyprovider/PEMHostKeyProvider.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.security.KeyPair;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.sshd.common.keyprovider.AbstractKeyPairProvider;
 import org.bouncycastle.openssl.PEMKeyPair;
@@ -35,16 +36,16 @@ import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
  */
 public class PEMHostKeyProvider extends AbstractKeyPairProvider {
 
-    private String path;
-    protected KeyPair keyPair;
+    private List<String> paths;
+    protected List<KeyPair> keyPairs;
     private final JcaPEMKeyConverter jcaHelper = new JcaPEMKeyConverter();
 
-    public PEMHostKeyProvider(String path) {
-        this.path = path;
+    public PEMHostKeyProvider(List<String> paths) {
+        this.paths = paths;
         loadKeys();
         // load a host key, and ensure we don't create it.
-        if (this.keyPair == null) {
-            throw new RuntimeException("Unable to load hostkeys from " + path);
+        if (this.keyPairs.isEmpty()) {
+            throw new RuntimeException("Unable to load hostkeys from " + paths);
         }
     }
 
@@ -65,7 +66,7 @@ public class PEMHostKeyProvider extends AbstractKeyPairProvider {
         try (InputStream is = new FileInputStream(f)) {
             return doReadKeyPair(is);
         } catch (Exception e) {
-            //log.info("Unable to read key {}: {}", path, e);
+            //log.info("Unable to read key {}: {}", paths, e);
             throw new RuntimeException(e);
         }
         //return null;
@@ -75,14 +76,14 @@ public class PEMHostKeyProvider extends AbstractKeyPairProvider {
     public synchronized Iterable<KeyPair> loadKeys() {
         ArrayList<KeyPair> keyPairList = new ArrayList<KeyPair>();
 
-        if (keyPair == null) {
+        for (String path : this.paths) {
             File f = new File(path);
             if (f.exists() && f.isFile()) {
-                keyPair = readKeyPair(f);
+                keyPairList.add(readKeyPair(f));
             }
         }
-        if (null != keyPair) {
-            keyPairList.add(keyPair);
+        if (this.keyPairs == null) {
+            this.keyPairs = keyPairList;
         }
 
         return keyPairList;

--- a/src/main/java/org/apache/sshd/server/keyprovider/PEMHostKeyProviderFactory.java
+++ b/src/main/java/org/apache/sshd/server/keyprovider/PEMHostKeyProviderFactory.java
@@ -13,9 +13,11 @@
 /* Some portions of this code are Copyright (c) 2014, Yahoo! Inc. All rights reserved. */
 package org.apache.sshd.server.keyprovider;
 
+import java.util.List;
+
 import org.apache.sshd.common.KeyPairProvider;
 
 public interface PEMHostKeyProviderFactory {
 
-    KeyPairProvider createPEMHostKeyProvider(String path);
+    KeyPairProvider createPEMHostKeyProvider(List<String> paths);
 }

--- a/src/main/java/org/apache/sshd/server/keyprovider/SshdPEMHostKeyProviderFactory.java
+++ b/src/main/java/org/apache/sshd/server/keyprovider/SshdPEMHostKeyProviderFactory.java
@@ -13,13 +13,15 @@
 /* Some portions of this code are Copyright (c) 2014, Yahoo! Inc. All rights reserved. */
 package org.apache.sshd.server.keyprovider;
 
+import java.util.List;
+
 import org.apache.sshd.common.KeyPairProvider;
 
 public class SshdPEMHostKeyProviderFactory implements PEMHostKeyProviderFactory {
 
     @Override
-    public KeyPairProvider createPEMHostKeyProvider(String path) {
-        return new PEMHostKeyProvider(path);
+    public KeyPairProvider createPEMHostKeyProvider(List<String> paths) {
+        return new PEMHostKeyProvider(paths);
     }
 
 }

--- a/src/test/java/com/yahoo/sshd/server/TestHostKey.java
+++ b/src/test/java/com/yahoo/sshd/server/TestHostKey.java
@@ -13,6 +13,7 @@
 package com.yahoo.sshd.server;
 
 import java.security.KeyPair;
+import java.util.Arrays;
 
 import org.apache.sshd.server.keyprovider.PEMHostKeyProvider;
 import org.testng.Assert;
@@ -23,7 +24,7 @@ public class TestHostKey {
     @Test
     public void testHostKey() {
         System.err.println("os.name=" + System.getProperty("os.name"));
-        PEMHostKeyProvider keyPairProvider = new PEMHostKeyProvider("src/test/resources/hostkey.pem");
+        PEMHostKeyProvider keyPairProvider = new PEMHostKeyProvider(Arrays.asList("src/test/resources/hostkey.pem"));
         Iterable<KeyPair> keys = keyPairProvider.loadKeys();
         Assert.assertNotNull(keys);
         // TODO: fix

--- a/src/test/java/com/yahoo/sshd/server/settings/TestOptions.java
+++ b/src/test/java/com/yahoo/sshd/server/settings/TestOptions.java
@@ -51,7 +51,7 @@ public class TestOptions {
         SshdSettingsInterface settings = builder.build();
 
         Assert.assertEquals(settings.getPort(), 2222);
-        Assert.assertEquals(settings.getHostKeyPath(), "src/test/resources/conf/sshd_proxy/ssh_host_dsa_key");
+        Assert.assertTrue(settings.getHostKeyPaths().contains("src/test/resources/conf/sshd_proxy/ssh_host_dsa_key"));
 
         // disabled by default
         Assert.assertEquals(settings.getHttpPort(), SshdSettingsBuilder.DEFAULT_JETTY_PORT);
@@ -91,7 +91,7 @@ public class TestOptions {
         SshdSettingsInterface settings = builder.build();
 
         Assert.assertEquals(settings.getPort(), 2222);
-        Assert.assertEquals(settings.getHostKeyPath(), "src/test/resources/conf/sshd_proxy/ssh_host_dsa_key");
+        Assert.assertTrue(settings.getHostKeyPaths().contains("src/test/resources/conf/sshd_proxy/ssh_host_dsa_key"));
 
         // disabled by default
         Assert.assertEquals(settings.getHttpPort(), SshdSettingsBuilder.DEFAULT_JETTY_PORT);
@@ -106,6 +106,16 @@ public class TestOptions {
         }
 
         Assert.assertEquals(list, SshdSettingsBuilder.DEFAULT_COMMAND_FACTORIES);
+    }
+
+    @Test
+    public void testMultipleHostKeys() throws Exception {
+        String[] args = new String[] {"-f", "src/test/resources/conf/sshd_proxy/sshd_proxy_hostkeys.properties"};
+        SshdSettingsBuilder builder = new SshdSettingsBuilder(args);
+        SshdSettingsInterface settings = builder.build();
+
+        Assert.assertTrue(settings.getHostKeyPaths().contains("src/test/resources/keys/test_ssh_key-0"));
+        Assert.assertTrue(settings.getHostKeyPaths().contains("src/test/resources/keys/test_ssh_key-10"));
     }
 
     @DataProvider

--- a/src/test/resources/conf/sshd_proxy/sshd_proxy_hostkeys.properties
+++ b/src/test/resources/conf/sshd_proxy/sshd_proxy_hostkeys.properties
@@ -1,0 +1,5 @@
+sshd.port=2222
+sshd.artifactoryUrl=http://your-test-artifactory-server:4080/
+sshd.artifactoryUsername=test_user_name
+sshd.artifactoryPassword=test_password
+sshd.hostKeyPath=src/test/resources/keys/test_ssh_key-0,src/test/resources/keys/test_ssh_key-10


### PR DESCRIPTION
This PR supports multiple hostkeys.

As background,  OpenSSH 7.0 and greater disabled `ssh-dss` by default.
Therefore, I'm considering that switch DSA to RSA.
However, needed backward-compatible for environments of using DSA.

A example of settings of multiple hostkeys in `sshd_proxy.properties`
```
sshd.root=developer_config
sshd.port=2222
sshd.artifactoryUrl=http://localhost:4080/artifactory
# use the default.
sshd.artifactoryUsername=admin
sshd.artifactoryPassword=password

# run artifactory in the same jvm
sshd.jetty.port=4080
sshd.jetty.webapp.dir=developer_config/webapps

# hostkey setting
sshd.hostKeyPath=./developer_config/conf/sshd_proxy/ssh_host_dsa_key,./developer_config/conf/sshd_proxy/ssh_host_rsa_key
```

The following outputs are results that verify support multiple hostkeys using above settings. 

```
$ ssh -o HostKeyAlgorithms="ssh-dss" -p 2222 localhost
The authenticity of host '[localhost]:2222 ([127.0.0.1]:2222)' can't be established.
DSA key fingerprint is 38:49:a1:28:12:5c:dd:41:69:d7:0b:41:7b:86:57:1b.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '[localhost]:2222' (DSA) to the list of known hosts.
*---------------------------------------------------*
|               _  _ _  _|    _-|-. _  _            |
|    this is a |_)| (_)(_||_|(_ | |(_)| | server    |
|              |                                    |
*---------------------------------------------------*
Connection to localhost closed.
```

```
$ ssh -o HostKeyAlgorithms="ssh-rsa" -p 2222 localhost
The authenticity of host '[localhost]:2222 ([127.0.0.1]:2222)' can't be established.
RSA key fingerprint is 24:08:6f:00:7f:38:6d:27:0d:fd:42:5e:e9:be:fb:15.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '[localhost]:2222' (RSA) to the list of known hosts.
*---------------------------------------------------*
|               _  _ _  _|    _-|-. _  _            |
|    this is a |_)| (_)(_||_|(_ | |(_)| | server    |
|              |                                    |
*---------------------------------------------------*
Connection to localhost closed.
```